### PR TITLE
Added calibration options and sample sketch

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -255,10 +255,10 @@ void Adafruit_BNO055::getCalibData(byte * pbuffer)
 {
   adafruit_bno055_opmode_t backupmode = _mode;
   setMode(OPERATION_MODE_CONFIG);
-  delay(25);
+  delay(20);
   readLen(ACCEL_OFFSET_X_LSB_ADDR, pbuffer, 22); //read the whole range of offsets
   setMode(backupmode); //return to previous opmode
-  delay(25);
+  delay(20);
 }
 
 /**************************************************************************/
@@ -270,11 +270,11 @@ void Adafruit_BNO055::setCalibData(byte * pbuffer)
 {
   adafruit_bno055_opmode_t backupmode = _mode;
   setMode(OPERATION_MODE_CONFIG);
-  delay(25);
+  delay(20);
   for(uint8_t i = 0; i < 22; i++)
     write8((adafruit_bno055_reg_t)((uint8_t)ACCEL_OFFSET_X_LSB_ADDR+i), pbuffer[i]); //write the whole range of offsets
   setMode(backupmode); //return to previous opmode
-  delay(25);
+  delay(20);
 }
 
 /**************************************************************************/

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -272,10 +272,7 @@ void Adafruit_BNO055::setCalibData(byte * pbuffer)
   setMode(OPERATION_MODE_CONFIG);
   delay(25);
   for(uint8_t i = 0; i < 22; i++)
-  {
-    Serial.println(pbuffer[i]);
     write8((adafruit_bno055_reg_t)((uint8_t)ACCEL_OFFSET_X_LSB_ADDR+i), pbuffer[i]); //write the whole range of offsets
-  }
   setMode(backupmode); //return to previous opmode
   delay(25);
 }

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -235,6 +235,53 @@ void Adafruit_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info)
 
 /**************************************************************************/
 /*!
+    @brief  Reads the calibration state (CALIB_STAT)
+*/
+/**************************************************************************/
+bool Adafruit_BNO055::getCalibState(adafruit_bno055_calib_stat_t mask)
+{
+/* See section 3.10 */
+uint8_t a;
+a = read8(BNO055_CALIB_STAT_ADDR);
+return ((a & mask) == mask);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads the calibration data 
+*/
+/**************************************************************************/
+void Adafruit_BNO055::getCalibData(byte * pbuffer)
+{
+	adafruit_bno055_opmode_t backupmode = _mode;
+	setMode(OPERATION_MODE_CONFIG);
+	delay(25);
+    readLen(ACCEL_OFFSET_X_LSB_ADDR, pbuffer, 22); //read the whole range of offsets
+	setMode(backupmode); //return to previous opmode
+	delay(25);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes previously acquired calibration data 
+*/
+/**************************************************************************/
+void Adafruit_BNO055::setCalibData(byte * pbuffer)
+{
+	adafruit_bno055_opmode_t backupmode = _mode;
+	setMode(OPERATION_MODE_CONFIG);
+	delay(25);
+	for(uint8_t i = 0; i < 22; i++)
+	{
+		Serial.println(pbuffer[i]);
+		write8((adafruit_bno055_reg_t)((uint8_t)ACCEL_OFFSET_X_LSB_ADDR+i), pbuffer[i]); //write the whole range of offsets
+	}
+	setMode(backupmode); //return to previous opmode
+	delay(25);
+}
+
+/**************************************************************************/
+/*!
     @brief  Gets teh temperature in degrees celsius
 */
 /**************************************************************************/

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -240,10 +240,10 @@ void Adafruit_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info)
 /**************************************************************************/
 bool Adafruit_BNO055::getCalibState(adafruit_bno055_calib_stat_t mask)
 {
-/* See section 3.10 */
-uint8_t a;
-a = read8(BNO055_CALIB_STAT_ADDR);
-return ((a & mask) == mask);
+  /* See section 3.10 */
+  uint8_t a;
+  a = read8(BNO055_CALIB_STAT_ADDR);
+  return ((a & mask) == mask);
 }
 
 /**************************************************************************/
@@ -253,12 +253,12 @@ return ((a & mask) == mask);
 /**************************************************************************/
 void Adafruit_BNO055::getCalibData(byte * pbuffer)
 {
-	adafruit_bno055_opmode_t backupmode = _mode;
-	setMode(OPERATION_MODE_CONFIG);
-	delay(25);
-    readLen(ACCEL_OFFSET_X_LSB_ADDR, pbuffer, 22); //read the whole range of offsets
-	setMode(backupmode); //return to previous opmode
-	delay(25);
+  adafruit_bno055_opmode_t backupmode = _mode;
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  readLen(ACCEL_OFFSET_X_LSB_ADDR, pbuffer, 22); //read the whole range of offsets
+  setMode(backupmode); //return to previous opmode
+  delay(25);
 }
 
 /**************************************************************************/
@@ -268,16 +268,16 @@ void Adafruit_BNO055::getCalibData(byte * pbuffer)
 /**************************************************************************/
 void Adafruit_BNO055::setCalibData(byte * pbuffer)
 {
-	adafruit_bno055_opmode_t backupmode = _mode;
-	setMode(OPERATION_MODE_CONFIG);
-	delay(25);
-	for(uint8_t i = 0; i < 22; i++)
-	{
-		Serial.println(pbuffer[i]);
-		write8((adafruit_bno055_reg_t)((uint8_t)ACCEL_OFFSET_X_LSB_ADDR+i), pbuffer[i]); //write the whole range of offsets
-	}
-	setMode(backupmode); //return to previous opmode
-	delay(25);
+  adafruit_bno055_opmode_t backupmode = _mode;
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  for(uint8_t i = 0; i < 22; i++)
+  {
+    Serial.println(pbuffer[i]);
+    write8((adafruit_bno055_reg_t)((uint8_t)ACCEL_OFFSET_X_LSB_ADDR+i), pbuffer[i]); //write the whole range of offsets
+  }
+  setMode(backupmode); //return to previous opmode
+  delay(25);
 }
 
 /**************************************************************************/

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -62,6 +62,7 @@ bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
   if(id != BNO055_ID)
   {
     delay(1000); // hold on for boot
+    id = read8(BNO055_CHIP_ID_ADDR);
     if(id != BNO055_ID) {
       return false;  // still not? ok bail
     }
@@ -320,7 +321,10 @@ imu::Quaternion Adafruit_BNO055::getQuat(void)
   z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
 
   /* Assign to Quaternion */
-  imu::Quaternion quat((double)w, (double)x, (double)y, (double)z);
+  /* See http://ae-bst.resource.bosch.com/media/products/dokumente/bno055/BST_BNO055_DS000_12~1.pdf
+     3.6.5.5 Orientation (Quaternion)  */
+  const double scale = (1.0 / (1<<14));
+  imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
   return quat;
 }
 

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -226,6 +226,14 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       uint16_t sw_rev;
       uint8_t  bl_rev;
     } adafruit_bno055_rev_info_t;
+    typedef enum
+	  { 
+	    /* bit masks to read the CALIB_STAT register */
+	    CALIB_STAT_SYS 										                      = 0xC0, 
+	    CALIB_STAT_GYR 										                      = 0x30, 
+	    CALIB_STAT_ACC 										                      = 0x0C,
+	    CALIB_STAT_MAG 										                      = 0x03
+	  } adafruit_bno055_calib_stat_t; 
 
     typedef enum
     {
@@ -241,6 +249,9 @@ class Adafruit_BNO055 : public Adafruit_Sensor
 
     bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF );
     void  setMode             ( adafruit_bno055_opmode_t mode );
+	  bool  getCalibState 	    ( adafruit_bno055_calib_stat_t );
+	  void  getCalibData		    ( byte *pbuffer);
+	  void  setCalibData		    ( byte *pbuffer);    
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -227,13 +227,13 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       uint8_t  bl_rev;
     } adafruit_bno055_rev_info_t;
     typedef enum
-	  { 
+    { 
 	    /* bit masks to read the CALIB_STAT register */
-	    CALIB_STAT_SYS 										                      = 0xC0, 
-	    CALIB_STAT_GYR 										                      = 0x30, 
-	    CALIB_STAT_ACC 										                      = 0x0C,
-	    CALIB_STAT_MAG 										                      = 0x03
-	  } adafruit_bno055_calib_stat_t; 
+      CALIB_STAT_SYS                                           = 0xC0, 
+      CALIB_STAT_GYR                                           = 0x30, 
+      CALIB_STAT_ACC                                           = 0x0C,
+      CALIB_STAT_MAG                                           = 0x03
+    } adafruit_bno055_calib_stat_t; 
 
     typedef enum
     {
@@ -249,9 +249,9 @@ class Adafruit_BNO055 : public Adafruit_Sensor
 
     bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF );
     void  setMode             ( adafruit_bno055_opmode_t mode );
-	  bool  getCalibState 	    ( adafruit_bno055_calib_stat_t );
-	  void  getCalibData		    ( byte *pbuffer);
-	  void  setCalibData		    ( byte *pbuffer);    
+    bool  getCalibState       ( adafruit_bno055_calib_stat_t );
+    void  getCalibData        ( byte *pbuffer);
+    void  setCalibData        ( byte *pbuffer);    
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -226,9 +226,10 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       uint16_t sw_rev;
       uint8_t  bl_rev;
     } adafruit_bno055_rev_info_t;
+    
     typedef enum
     { 
-	    /* bit masks to read the CALIB_STAT register */
+      /* bit masks to read the CALIB_STAT register */
       CALIB_STAT_SYS                                           = 0xC0, 
       CALIB_STAT_GYR                                           = 0x30, 
       CALIB_STAT_ACC                                           = 0x0C,

--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -33,7 +33,7 @@ void setup()
   
   /* You will need the next two commented lines in your own sketch, _immediatly_ after bno.begin() to use a
     predefined calibration
-  const byte c_data[22] = {0, 0, 0, 0, 0, 0, 172, 250, 112, 255, 52, 253, 0, 0, 253, 255, 255, 255, 232, 3, 240, 2}; //replace this line with the serial output of this sketch
+  byte c_data[22] = {0, 0, 0, 0, 0, 0, 172, 250, 112, 255, 52, 253, 0, 0, 253, 255, 255, 255, 232, 3, 240, 2}; //replace this line with the serial output of this sketch
   bno.setCalibData(c_data);*/
   
   delay(1000);
@@ -72,7 +72,7 @@ void loop()
   byte buffer[22];
   bno.getCalibData(buffer);
   /* Prints the actual line to paste into your sketch (see setup() above) */
-  Serial.print("const byte c_data[22] = {");
+  Serial.print("byte c_data[22] = {");
   for (int i = 0; i < 22; i++)
   {
     Serial.print(buffer[i]); 

--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -1,0 +1,81 @@
+/*******************************************************************************************************************************************************************************************
+*  Adafruit BNO055 Sensor Calibration sample
+*  Refer to http://www.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf
+*  Section 3.10 on how to calibrate your sensor:
+*   -Run this sketch
+*   -To calibrate the Gyroscope, just let the sensor sit for a couple of seconds until GYR Calibration shows 1
+*   -To calibrate the Magnetometer, move your sensor in random figure 8 patterns until MAG Calibration shows 1
+*   -If you want to calibrate the acceleration sensor, move the sensor to 6 stable positions slowly, 3 of those should be in the XY/XZ/YZ plane
+*   -Once you are happy with the readings you get, copy the c_data = .... line from serial.console to the setup() of your sketch and write it to the sensor with "bno.setCalibData(c_data);"
+********************************************************************************************************************************************************************************************/
+
+#include <Adafruit_Sensor.h>
+#include <utility/imumaths.h>
+#include <Wire.h>
+#include <Adafruit_BNO055.h>
+
+Adafruit_BNO055 bno = Adafruit_BNO055(55);
+
+void setup()
+{
+  Serial.begin(9600);
+  Serial.println("Orientation Sensor Calibration"); Serial.println("");
+
+  /* Initialise the sensor */
+  if (!bno.begin(bno.OPERATION_MODE_NDOF)) //if you want to calibrate using another mode, set it here. OPERATION_MODE_COMPASS for a precise tilt compensated compass (Section 3.3.2 / 3.3.3)
+  {
+    /* There was a problem detecting the BNO055 ... check your connections */
+    Serial.print("Ooops, no BNO055 detected ... Check your wiring or I2C ADDR!");
+    while (1);
+  }
+  
+  /* You will need the next two commented lines in your own sketch, _immediatly_ after bno.begin() to use a predefined calibration
+  const byte c_data[22] = {0, 0, 0, 0, 0, 0, 172, 250, 112, 255, 52, 253, 0, 0, 253, 255, 255, 255, 232, 3, 240, 2}; //replace this line with the serial output of this sketch
+  bno.setCalibData(c_data);*/
+  
+  delay(1000);
+  bno.setExtCrystalUse(true);
+}
+
+void loop()
+{
+  sensors_event_t event;
+  bno.getEvent(&event);
+
+  /* Prints the euler angles for reference */
+  Serial.print("X: "); //"heading"
+  Serial.print(event.orientation.x, 4);
+  Serial.print(" Y: ");
+  Serial.print(event.orientation.y, 4);
+  Serial.print(" Z: ");
+  Serial.print(event.orientation.z, 4);
+  Serial.println();
+
+  /* Shows the calibration states for all 3 sensors + system. Optimally, in NDOF mode you want all these to read "1" 
+    before you assume good calibration (Note: Some sensors are off in other modes)*/
+  bool bMAG = bno.getCalibState(bno.CALIB_STAT_MAG);
+  Serial.print("MAG Calibration: ");
+  Serial.println(bMAG);
+  bool bGYR = bno.getCalibState(bno.CALIB_STAT_GYR);
+  Serial.print("GYR Calibration: ");
+  Serial.println(bGYR);
+  bool bACC = bno.getCalibState(bno.CALIB_STAT_ACC);
+  Serial.print("ACC Calibration: ");
+  Serial.println(bACC);
+  bool b = bno.getCalibState(bno.CALIB_STAT_SYS);
+  Serial.print("SYS Calibration: ");
+  Serial.println(b);
+
+  byte buffer[22];
+  bno.getCalibData(buffer);
+  /* Prints the actual line to paste into your sketch (see setup() above) */
+  Serial.print("byte c_data[22] = {");
+  for (int i = 0; i < 22; i++)
+  {
+    Serial.print(buffer[i]); 
+    if(i!=21) Serial.print(", ");
+  }
+  Serial.println("};");
+  
+  delay(500);
+}

--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -5,8 +5,10 @@
 *   -Run this sketch
 *   -To calibrate the Gyroscope, just let the sensor sit for a couple of seconds until GYR Calibration shows 1
 *   -To calibrate the Magnetometer, move your sensor in random figure 8 patterns until MAG Calibration shows 1
-*   -If you want to calibrate the acceleration sensor, move the sensor to 6 stable positions slowly, 3 of those should be in the XY/XZ/YZ plane
-*   -Once you are happy with the readings you get, copy the c_data = .... line from serial.console to the setup() of your sketch and write it to the sensor with "bno.setCalibData(c_data);"
+*   -If you want to calibrate the acceleration sensor, move the sensor to 6 stable positions slowly, 3 of those 
+*    should be in the XY/XZ/YZ plane
+*   -Once you are happy with the readings you get, copy the c_data = .... line from serial.console to the setup()
+*    of your sketch and write it to the sensor with "bno.setCalibData(c_data);"
 ********************************************************************************************************************************************************************************************/
 
 #include <Adafruit_Sensor.h>
@@ -22,14 +24,15 @@ void setup()
   Serial.println("Orientation Sensor Calibration"); Serial.println("");
 
   /* Initialise the sensor */
-  if (!bno.begin(bno.OPERATION_MODE_NDOF)) //if you want to calibrate using another mode, set it here. OPERATION_MODE_COMPASS for a precise tilt compensated compass (Section 3.3.2 / 3.3.3)
+  if (!bno.begin(bno.OPERATION_MODE_NDOF)) //if you want to calibrate using another mode, set it here. (Section 3.3.2 / 3.3.3)
   {
     /* There was a problem detecting the BNO055 ... check your connections */
     Serial.print("Ooops, no BNO055 detected ... Check your wiring or I2C ADDR!");
     while (1);
   }
   
-  /* You will need the next two commented lines in your own sketch, _immediatly_ after bno.begin() to use a predefined calibration
+  /* You will need the next two commented lines in your own sketch, _immediatly_ after bno.begin() to use a
+    predefined calibration
   const byte c_data[22] = {0, 0, 0, 0, 0, 0, 172, 250, 112, 255, 52, 253, 0, 0, 253, 255, 255, 255, 232, 3, 240, 2}; //replace this line with the serial output of this sketch
   bno.setCalibData(c_data);*/
   

--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -72,7 +72,7 @@ void loop()
   byte buffer[22];
   bno.getCalibData(buffer);
   /* Prints the actual line to paste into your sketch (see setup() above) */
-  Serial.print("byte c_data[22] = {");
+  Serial.print("const byte c_data[22] = {");
   for (int i = 0; i < 22; i++)
   {
     Serial.print(buffer[i]); 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BNO055
-version=1.0.1
+version=1.0.4
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit BNO055 Absolute Orientation Sensor.

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -76,7 +76,24 @@ public:
         return _z;
     }
 
-    double magnitude()
+    double w() const
+    {
+        return _w;
+    }
+    double x() const
+    {
+        return _x;
+    }
+    double y() const
+    {
+        return _y;
+    }
+    double z() const
+    {
+        return _z;
+    }
+
+    double magnitude() const
     {
         double res = (_w*_w) + (_x*_x) + (_y*_y) + (_z*_z);
         return sqrt(res);
@@ -84,12 +101,12 @@ public:
 
     void normalize()
     {
-		double mag = magnitude();
+        double mag = magnitude();
         *this = this->scale(1/mag);
     }
 
 
-    Quaternion conjugate()
+    Quaternion conjugate() const
     {
         Quaternion q;
         q.w() = _w;
@@ -148,7 +165,7 @@ public:
         }
     }
 
-    void toAxisAngle(Vector<3>& axis, float& angle)
+    void toAxisAngle(Vector<3>& axis, float& angle) const
     {
         float sqw = sqrt(1-_w*_w);
         if(sqw == 0) //it's a singularity and divide by zero, avoid
@@ -160,7 +177,7 @@ public:
         axis.z() = _z / sqw;
     }
 
-    Matrix<3> toMatrix()
+    Matrix<3> toMatrix() const
     {
         Matrix<3> ret;
         ret.cell(0, 0) = 1-(2*(_y*_y))-(2*(_z*_z));
@@ -178,7 +195,18 @@ public:
     }
 
 
-    Vector<3> toEuler()
+    // Returns euler angles that represent the quaternion.  Angles are
+    // returned in rotation order and right-handed about the specified
+    // axes:
+    //
+    //   v[0] is applied 1st about z (ie, roll)
+    //   v[1] is applied 2nd about y (ie, pitch)
+    //   v[2] is applied 3rd about x (ie, yaw)
+    //
+    // Note that this means result.x() is not a rotation about x;
+    // similarly for result.z().
+    //
+    Vector<3> toEuler() const
     {
         Vector<3> ret;
         double sqw = _w*_w;
@@ -193,7 +221,7 @@ public:
         return ret;
     }
 
-    Vector<3> toAngularVelocity(float dt)
+    Vector<3> toAngularVelocity(float dt) const
     {
         Vector<3> ret;
         Quaternion one(1.0, 0.0, 0.0, 0.0);
@@ -208,13 +236,13 @@ public:
         return ret;
     }
 
-    Vector<3> rotateVector(Vector<2> v)
+    Vector<3> rotateVector(Vector<2> v) const
     {
         Vector<3> ret(v.x(), v.y(), 0.0);
         return rotateVector(ret);
     }
 
-    Vector<3> rotateVector(Vector<3> v)
+    Vector<3> rotateVector(Vector<3> v) const
     {
         Vector<3> qv(this->x(), this->y(), this->z());
         Vector<3> t;
@@ -223,7 +251,7 @@ public:
     }
 
 
-    Quaternion operator * (Quaternion q)
+    Quaternion operator * (Quaternion q) const
     {
         Quaternion ret;
         ret._w = ((_w*q._w) - (_x*q._x) - (_y*q._y) - (_z*q._z));
@@ -233,7 +261,7 @@ public:
         return ret;
     }
 
-    Quaternion operator + (Quaternion q)
+    Quaternion operator + (Quaternion q) const
     {
         Quaternion ret;
         ret._w = _w + q._w;
@@ -243,7 +271,7 @@ public:
         return ret;
     }
 
-    Quaternion operator - (Quaternion q)
+    Quaternion operator - (Quaternion q) const
     {
         Quaternion ret;
         ret._w = _w - q._w;
@@ -253,7 +281,7 @@ public:
         return ret;
     }
 
-    Quaternion operator / (float scalar)
+    Quaternion operator / (float scalar) const
     {
         Quaternion ret;
         ret._w = this->_w/scalar;
@@ -263,7 +291,7 @@ public:
         return ret;
     }
 
-    Quaternion operator * (float scalar)
+    Quaternion operator * (float scalar) const
     {
         Quaternion ret;
         ret._w = this->_w*scalar;
@@ -273,8 +301,8 @@ public:
         return ret;
     }
 
-	Quaternion scale(double scalar)
-	{
+    Quaternion scale(double scalar) const
+    {
         Quaternion ret;
         ret._w = this->_w*scalar;
         ret._x = this->_x*scalar;

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -125,8 +125,8 @@ public:
     {
         Vector ret;
 
-         //the cross product is only valid for vectors with 3 dimensions,
-         //with the exception of higher dimensional stuff that is beyond the intended scope of this library
+        // The cross product is only valid for vectors with 3 dimensions,
+        // with the exception of higher dimensional stuff that is beyond the intended scope of this library
         if(N != 3)
             return ret;
 
@@ -136,7 +136,7 @@ public:
         return ret;
     }
 
-    Vector scale(double scalar)
+    Vector scale(double scalar) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -144,7 +144,7 @@ public:
         return ret;
     }
 
-    Vector invert()
+    Vector invert() const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -164,12 +164,22 @@ public:
         return p_vec[n];
     }
 
+    double operator [](int n) const
+    {
+        return p_vec[n];
+    }
+
     double& operator ()(int n)
     {
         return p_vec[n];
     }
 
-    Vector operator + (Vector v)
+    double operator ()(int n) const
+    {
+        return p_vec[n];
+    }
+
+    Vector operator + (Vector v) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -177,7 +187,7 @@ public:
         return ret;
     }
 
-    Vector operator - (Vector v)
+    Vector operator - (Vector v) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -185,12 +195,12 @@ public:
         return ret;
     }
 
-    Vector operator * (double scalar)
+    Vector operator * (double scalar) const
     {
         return scale(scalar);
     }
 
-    Vector operator / (double scalar)
+    Vector operator / (double scalar) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -213,6 +223,9 @@ public:
     double& x() { return p_vec[0]; }
     double& y() { return p_vec[1]; }
     double& z() { return p_vec[2]; }
+    double x() const { return p_vec[0]; }
+    double y() const { return p_vec[1]; }
+    double z() const { return p_vec[2]; }
 
 
 private:

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -34,20 +34,17 @@ template <uint8_t N> class Vector
 public:
     Vector()
     {
-        p_vec = &p_vec_data[0];
         memset(p_vec, 0, sizeof(double)*N);
     }
 
     Vector(double a)
     {
-        p_vec = &p_vec_data[0];
         memset(p_vec, 0, sizeof(double)*N);
         p_vec[0] = a;
     }
 
     Vector(double a, double b)
     {
-        p_vec = &p_vec_data[0];
         memset(p_vec, 0, sizeof(double)*N);
         p_vec[0] = a;
         p_vec[1] = b;
@@ -55,7 +52,6 @@ public:
 
     Vector(double a, double b, double c)
     {
-        p_vec = &p_vec_data[0];
         memset(p_vec, 0, sizeof(double)*N);
         p_vec[0] = a;
         p_vec[1] = b;
@@ -64,7 +60,6 @@ public:
 
     Vector(double a, double b, double c, double d)
     {
-        p_vec = &p_vec_data[0];
         memset(p_vec, 0, sizeof(double)*N);
         p_vec[0] = a;
         p_vec[1] = b;
@@ -74,9 +69,7 @@ public:
 
     Vector(const Vector<N> &v)
     {
-        p_vec = &p_vec_data[0];
-        memset(p_vec, 0, sizeof(double)*N);
-        for (int x = 0; x < N; x++ )
+        for (int x = 0; x < N; x++)
             p_vec[x] = v.p_vec[x];
     }
 
@@ -229,8 +222,7 @@ public:
 
 
 private:
-    double* p_vec;
-    double  p_vec_data[N];
+    double  p_vec[N];
 };
 
 

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -95,7 +95,7 @@ public:
 
         if(isnan(res))
             return 0;
-        if((fabs(res)-1) >= 0.000001) //avoid a sqrt if possible
+        if((fabs(res-1)) >= 0.000001) // Avoid a sqrt if possible.
             return sqrt(res);
         return 1;
     }


### PR DESCRIPTION
Added calibration functions to library:

bool Adafruit_BNO055::getCalibState(adafruit_bno055_calib_stat_t mask)
 Takes a adafruit_bno055_calib_stat_t mask and returns the related calibration state
 Returns true if calibrated
 Valid masks are:
    typedef enum
    { 
      /\* bit masks to read the CALIB_STAT register */
      CALIB_STAT_SYS                                           = 0xC0, //Overall system calibration state
      CALIB_STAT_GYR                                           = 0x30, //State for gyroscope
      CALIB_STAT_ACC                                           = 0x0C, //State for accelerometer
      CALIB_STAT_MAG                                           = 0x03 //State for magnetometer
    } adafruit_bno055_calib_stat_t; 

void Adafruit_BNO055::getCalibData(byte \* pbuffer)
 Takes a len=22 array of bytes and writes the currently active calibration into the array

void Adafruit_BNO055::setCalibData(byte \* pbuffer)
 Takes a len=22 array of bytes of calibration data and writes it into the sensor. This function must be
 called directly after .begin()

Added a calibration sample sketch to the library:
calibration.ino will allow any user to perform an easy calibration of his sensor to use in his own sketches. 
